### PR TITLE
fixing the IN operator syntax and adding ANY, SOME, ALL operators to where clause

### DIFF
--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -130,7 +130,7 @@ func chkInvalidIdentifier(identifer ...string) bool {
 // WhereByRequest create interface for queries + where
 func WhereByRequest(r *http.Request, initialPlaceholderID int) (whereSyntax string, values []interface{}, err error) {
 	whereKey := []string{}
-	whereValues := []interface{}{}
+	whereValues := []string{}
 	var value, op string
 
 	pid := initialPlaceholderID
@@ -194,7 +194,7 @@ func WhereByRequest(r *http.Request, initialPlaceholderID int) (whereSyntax stri
 
 			case "ANY", "SOME", "ALL":
 				whereKey = append(whereKey, fmt.Sprintf(`%s = %s ($%d)`, key, op, pid))
-				whereValues = append(whereValues, pq.Array(strings.Split(value, ",")))
+				whereValues = append(whereValues, FormatArray(strings.Split(value, ",")))
 				pid++
 			case "IS NULL", "IS NOT NULL":
 				whereKey = append(whereKey, fmt.Sprintf(`%s %s`, key, op))

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -14,7 +14,6 @@ import (
 	"unicode"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/lib/pq"
 	"github.com/nuveo/log"
 	"github.com/prest/adapters/postgres/connection"
 	"github.com/prest/adapters/postgres/internal/scanner"
@@ -191,20 +190,17 @@ func WhereByRequest(r *http.Request, initialPlaceholderID int) (whereSyntax stri
 				}
 				pid += len(v)
 				whereKey = append(whereKey, fmt.Sprintf(`%s %s (%s)`, key, op, strings.Join(keyParams, ",")))
-
 			case "ANY", "SOME", "ALL":
 				whereKey = append(whereKey, fmt.Sprintf(`%s = %s ($%d)`, key, op, pid))
 				whereValues = append(whereValues, FormatArray(strings.Split(value, ",")))
 				pid++
 			case "IS NULL", "IS NOT NULL":
 				whereKey = append(whereKey, fmt.Sprintf(`%s %s`, key, op))
-
 			case "=", "!=", ">", ">=", "<", "<=":
 				whereKey = append(whereKey, fmt.Sprintf(`%s %s $%d`, key, op, pid))
 				whereValues = append(whereValues, value)
 				pid++
 			}
-
 		}
 	}
 
@@ -215,10 +211,10 @@ func WhereByRequest(r *http.Request, initialPlaceholderID int) (whereSyntax stri
 			whereSyntax += " AND " + whereKey[i]
 		}
 	}
-	if len(whereValues) > 0 {
-		values = whereValues
-	}
 
+	for i := 0; i < len(whereValues); i++ {
+		values = append(values, whereValues[i])
+	}
 	return
 }
 

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -196,7 +196,7 @@ func WhereByRequest(r *http.Request, initialPlaceholderID int) (whereSyntax stri
 				pid++
 			case "IS NULL", "IS NOT NULL":
 				whereKey = append(whereKey, fmt.Sprintf(`%s %s`, key, op))
-			case "=", "!=", ">", ">=", "<", "<=":
+			default: // "=", "!=", ">", ">=", "<", "<="
 				whereKey = append(whereKey, fmt.Sprintf(`%s %s $%d`, key, op, pid))
 				whereValues = append(whereValues, value)
 				pid++

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -684,6 +684,9 @@ func TestGetQueryOperator(t *testing.T) {
 		{"$lte", "<="},
 		{"$in", "IN"},
 		{"$nin", "NOT IN"},
+		{"$any", "ANY"},
+		{"$some", "SOME"},
+		{"$all", "ALL"},
 		{"$notnull", "IS NOT NULL"},
 		{"$null", "IS NULL"},
 	}


### PR DESCRIPTION
Hi,

I couldn't make $in. operator to work as it was producing malformed sql query.

The problem with pq lib is that the IN clause is not really properly supported and it is better to use arrays with ANY operator. Therefore I've added support for $any. $some. and $all.

The syntax to pass multiple values is as follows:
http://127.0.0.1:8000/DATABASE/SCHEMA/TABLE?id=$any.14,2,5
http://127.0.0.1:8000/DATABASE/SCHEMA/TABLE?string_id=$any.'14','2','5'

Best Regards
Cezary