### PR TITLE
Group function alias names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,13 @@ os:
     - linux
 
 go:
-  - 1.9
-  - "1.10"
-  - tip
+  - "1.12.x"
+  - "1.11.x"
+  - "1.10.x"
+  - master
+
+# allow internal package imports in forked repositories
+go_import_path: github.com/prest/adapters
 
 matrix:
   allow_failures:

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -1281,6 +1281,9 @@ func NormalizeGroupFunction(paramValue string) (groupFuncSQL string, err error) 
 			values[1] = fmt.Sprintf(`"%s"`, v)
 		}
 		groupFuncSQL = fmt.Sprintf(`%s(%s)`, groupFunc, values[1])
+		if len(values) == 3 {
+			groupFuncSQL = fmt.Sprintf(`%s AS "%s"`, groupFuncSQL, values[2])
+		}
 		return
 	default:
 		err = fmt.Errorf("this function %s is not a valid group function", groupFunc)

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -1030,6 +1030,13 @@ func TestNormalizeGroupFunction(t *testing.T) {
 		{"Normalize MEDIAN Function", "median:age", `MEDIAN("age")`},
 		{"Normalize STDDEV Function", "stddev:age", `STDDEV("age")`},
 		{"Normalize VARIANCE Function", "variance:age", `VARIANCE("age")`},
+		{"Normalize AVG Function renamed", "avg:age:colname", `AVG("age") AS "colname"`},
+		{"Normalize SUM Function renamed", "sum:age:colname", `SUM("age") AS "colname"`},
+		{"Normalize MAX Function renamed", "max:age:colname", `MAX("age") AS "colname"`},
+		{"Normalize MIN Function renamed", "min:age:colname", `MIN("age") AS "colname"`},
+		{"Normalize MEDIAN Function renamed", "median:age:colname", `MEDIAN("age") AS "colname"`},
+		{"Normalize STDDEV Function renamed", "stddev:age:colname", `STDDEV("age") AS "colname"`},
+		{"Normalize VARIANCE Function renamed", "variance:age:colname", `VARIANCE("age") AS "colname"`},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The current output when an aggregate function is used multiple times in a query looks like this and makes it impossible to distinguish the columns
```
[
    {
        "column1": "abc",
        "sum": 10,
        "sum": 20,
    }
]
```

This enables the syntax `_select=column1,sum:column2:alias2,sum:column3:alias3&_groupby=column1` to return
```
[
    {
        "column1": "abc",
        "alias2": 10,
        "alias3": 20,
    }
]
```

Also related to https://github.com/prest/prest/issues/216 