### PR TITLE
avoid panic on tx.commit calls

### DIFF
--- a/mock/conn.go
+++ b/mock/conn.go
@@ -1,0 +1,14 @@
+package mock
+
+import (
+	"database/sql/driver"
+)
+
+// mockConn is the mock of driver.Conn
+type mockConn struct{}
+
+func (mc *mockConn) Begin() (driver.Tx, error)                    { return mc, nil }
+func (mc *mockConn) Close() (err error)                           { return }
+func (mc *mockConn) Prepare(q string) (st driver.Stmt, err error) { return }
+func (mc *mockConn) Commit() (err error)                          { return }
+func (mc *mockConn) Rollback() (err error)                        { return }

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -36,7 +36,7 @@ func New(t *testing.T) (m *Mock) {
 		mtx: &sync.RWMutex{},
 		t:   t,
 	}
-	sql.Register("mock", &Mock{})
+	sql.Register("mock", m)
 	return
 }
 
@@ -142,7 +142,6 @@ func (m *Mock) PaginateIfPossible(r *http.Request) (paginatedQuery string, err e
 
 // GetTransaction mock
 func (m *Mock) GetTransaction() (tx *sql.Tx, err error) {
-	m.t.Helper()
 	db, err := sql.Open("mock", "prest")
 	if err != nil {
 		return

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -3,6 +3,8 @@ package mock
 import (
 	"bytes"
 	"database/sql"
+	"database/sql/driver"
+	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -24,6 +26,7 @@ type Item struct {
 type Mock struct {
 	mtx   *sync.RWMutex
 	t     *testing.T
+	conns map[string]*mockConn
 	Items []Item
 }
 
@@ -32,6 +35,19 @@ func New(t *testing.T) (m *Mock) {
 	m = &Mock{
 		mtx: &sync.RWMutex{},
 		t:   t,
+	}
+	sql.Register("mock", &Mock{})
+	return
+}
+
+// Open makes Mock implement driver.Driver
+func (m *Mock) Open(dsn string) (c driver.Conn, err error) {
+	m.t.Helper()
+	m.conns = make(map[string]*mockConn)
+	m.conns["prest"] = &mockConn{}
+	c, ok := m.conns[dsn]
+	if !ok {
+		return c, fmt.Errorf("expected a connection to be available, but it is not")
 	}
 	return
 }
@@ -126,7 +142,12 @@ func (m *Mock) PaginateIfPossible(r *http.Request) (paginatedQuery string, err e
 
 // GetTransaction mock
 func (m *Mock) GetTransaction() (tx *sql.Tx, err error) {
-	return
+	m.t.Helper()
+	db, err := sql.Open("mock", "prest")
+	if err != nil {
+		return
+	}
+	return db.Begin()
 }
 
 // Query mock

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -36,6 +36,12 @@ func New(t *testing.T) (m *Mock) {
 		mtx: &sync.RWMutex{},
 		t:   t,
 	}
+	drivers := sql.Drivers()
+	for _, driver := range drivers {
+		if driver == "mock" {
+			return
+		}
+	}
 	sql.Register("mock", m)
 	return
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -2,7 +2,9 @@ package mock
 
 import (
 	"bytes"
+	"database/sql"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -10,6 +12,7 @@ import (
 	"github.com/prest/adapters"
 	"github.com/prest/adapters/scanner"
 	"github.com/prest/config"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMock_validate(t *testing.T) {
@@ -426,6 +429,41 @@ func TestMock_Query(t *testing.T) {
 			if gotSc := m.Query(""); !reflect.DeepEqual(gotSc, tt.wantSc) {
 				t.Errorf("Mock.Query() = %v, want %v", gotSc, tt.wantSc)
 			}
+		})
+	}
+}
+
+func TestMock_GetTransaction(t *testing.T) {
+	sql.Register("mock", &Mock{})
+	type fields struct {
+		mtx *sync.RWMutex
+		t   *testing.T
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantTx  *sql.Tx
+		wantErr bool
+	}{
+		{
+			name:    "transaction not nil",
+			fields:  fields{},
+			wantErr: false,
+			wantTx:  &sql.Tx{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Mock{
+				mtx: tt.fields.mtx,
+				t:   tt.fields.t,
+			}
+			gotTx, err := m.GetTransaction()
+			errMactches := ((err != nil) != tt.wantErr)
+			assert.False(t, errMactches, fmt.Sprintf("Mock.GetTransaction() error = %v, wantErr %v", err, tt.wantErr))
+			assert.NotNil(t, gotTx)
+			// should not panic on commit
+			assert.Nil(t, gotTx.Commit())
 		})
 	}
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -434,7 +434,6 @@ func TestMock_Query(t *testing.T) {
 }
 
 func TestMock_GetTransaction(t *testing.T) {
-	sql.Register("mock", &Mock{})
 	type fields struct {
 		mtx *sync.RWMutex
 		t   *testing.T
@@ -454,10 +453,7 @@ func TestMock_GetTransaction(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &Mock{
-				mtx: tt.fields.mtx,
-				t:   tt.fields.t,
-			}
+			m := New(t)
 			gotTx, err := m.GetTransaction()
 			errMactches := ((err != nil) != tt.wantErr)
 			assert.False(t, errMactches, fmt.Sprintf("Mock.GetTransaction() error = %v, wantErr %v", err, tt.wantErr))


### PR DESCRIPTION
Hey guys,

While using this mock pkg I came across a commit panic when the mock tx was used to commit. I made a branch that shows how this panic occurs ([here](https://github.com/levpay/adapters/blob/6c57b4806c971fe7ff17f7e631aaca39d1fcf0a8/mock/mock_test.go#L436)).

This PR does:
- makes `Mock` struct implement the driver.Driver interface
- registers a new driver "mock" on `New`
- returns a fake db tx on `mock.GetTransaction`
- implements `mockConn` that allows `Mock{}` to return a mocked connection